### PR TITLE
Update build workflow to new naming of archive files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ needs.parameters.outputs.githubRelease }}
-          file: target/products/org.openjdk.jmc-linux.gtk.x86_64.tar.gz
+          file: target/products/org.openjdk.jmc-${{ needs.parameters.outputs.jmcVersion }}-linux.gtk.x86_64.tar.gz
           asset_name: sap.jmc-${{ needs.parameters.outputs.jmcVersion }}-linux.gtk.x86_64.tar.gz
           overwrite: ${{ needs.parameters.outputs.release != 'true' }}
 
@@ -249,7 +249,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           tag: ${{ needs.parameters.outputs.githubRelease }}
-          file: target/products/org.openjdk.jmc-macosx.cocoa.aarch64.tar.gz
+          file: target/products/org.openjdk.jmc-${{ needs.parameters.outputs.jmcVersion }}-macosx.cocoa.aarch64.tar.gz
           asset_name: sap.jmc-${{ needs.parameters.outputs.jmcVersion }}-macosx.cocoa.aarch64.tar.gz
           overwrite: ${{ needs.parameters.outputs.release != 'true' }}
 
@@ -258,7 +258,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           tag: ${{ needs.parameters.outputs.githubRelease }}
-          file: target/products/org.openjdk.jmc-macosx.cocoa.x86_64.tar.gz
+          file: target/products/org.openjdk.jmc-${{ needs.parameters.outputs.jmcVersion }}-macosx.cocoa.x86_64.tar.gz
           asset_name: sap.jmc-${{ needs.parameters.outputs.jmcVersion }}-macosx.cocoa.x86_64.tar.gz
           overwrite: ${{ needs.parameters.outputs.release != 'true' }}
 
@@ -267,7 +267,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           tag: ${{ needs.parameters.outputs.githubRelease }}
-          file: target/products/org.openjdk.jmc-win32.win32.x86_64.zip
+          file: target/products/org.openjdk.jmc-${{ needs.parameters.outputs.jmcVersion }}-win32.win32.x86_64.zip
           asset_name: sap.jmc-${{ needs.parameters.outputs.jmcVersion }}-win32.win32.x86_64.zip
           overwrite: ${{ needs.parameters.outputs.release != 'true' }}
 


### PR DESCRIPTION
JMC build has been modified upstream so we have to adapt our workflow.