### PR TITLE
Bump build JDK to 21 and use SapMachine

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,10 +158,10 @@ jobs:
       - name: Set up build JDK
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
-          java-version: '17'
+          distribution: sapmachine
+          java-version: '21'
           java-package: jdk
-          mvn-toolchain-id: 'JavaSE-17'
+          mvn-toolchain-id: 'JavaSE-21'
 
       - name: Cache local Maven repository
         uses: actions/cache@v4


### PR DESCRIPTION
The Eclipse platform has been updated and we also have SapMachine in the setup-java action.