### PR TITLE
Fixed problems in the unsafe allocation test.

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -107,7 +107,7 @@
 			<id>SapAgent</id>
 			<properties>
 				<agent.name>SapAgent</agent.name>
-				<revision>0.9.0</revision>
+				<revision>0.9.1</revision>
 			</properties>
 			<build>
 				<plugins>

--- a/agent/src/main/java/org/openjdk/jmc/agent/sap/boot/converters/UnsafeMemoryAllocationLogger.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/sap/boot/converters/UnsafeMemoryAllocationLogger.java
@@ -56,8 +56,8 @@ public class UnsafeMemoryAllocationLogger {
 				MIN_SIZE, "The minimum size of the live allocations to dump the result.",
 				MIN_STACK_SIZE, "The minimum size of a stack to be included in a dump.",
 				MIN_PERCENTAGE, "The minimum percentage compared to the last dump to print a dump.",
-				MIN_AGE, "The minimum age in minutes to include an allocation in the output.",
-				MAX_AGE, "The maximum age in minutes to include an allocation in the output.",
+				MIN_AGE, "The minimum age to include an allocation in the output.",
+				MAX_AGE, "The maximum age to include an allocation in the output.",
 				MUST_CONTAIN, "A regexp which must match at least one frame to be printed.",
 				MUST_NOT_CONTAIN, "A regexp which must not match any frame to be printed.");
 		command = new Command(dumpCommand,

--- a/agent/src/main/java/org/openjdk/jmc/agent/sap/boot/util/Arguments.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/sap/boot/util/Arguments.java
@@ -151,9 +151,9 @@ public class Arguments {
 		return defaultRersult;
 	}
 
-	private long parseUnits(String option, long defaultRersult, char[] suffixes, long[] scale) {
+	private long parseUnits(String option, long defaultResult, char[] suffixes, long[] scale) {
 		if (!args.containsKey(option)) {
-			return defaultRersult;
+			return defaultResult;
 		}
 
 		String rest = getString(option, "");

--- a/agent/src/test/java/org/openjdk/jmc/agent/sap/test/UnsafeAllocationTest.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/sap/test/UnsafeAllocationTest.java
@@ -105,7 +105,7 @@ public class UnsafeAllocationTest extends TestBase {
 
 	public void testNativeAllocs() throws IOException {
 		JavaAgentRunner runner = getRunner("traceUnsafeAllocations,logDest=stdout", "--add-opens",
-				"java.base/jdk.internal.misc=ALL-UNNAMED");
+				"java.base/jdk.internal.misc=ALL-UNNAMED", "-XX:NativeMemoryTracking=off");
 		runner.start(DO_NATIVE_ALLOCS);
 		runner.waitForDone();
 		runner.loadAgent("dump=unsafeAllocations,logDest=stderr,mustContain=doNativeAllocs");
@@ -129,7 +129,7 @@ public class UnsafeAllocationTest extends TestBase {
 				"Printed 1 of 2 allocations with 750 bytes");
 		runner.start(DO_NATIVE_ALLOCS);
 		runner.waitForDone();
-		runner.loadAgent("dump=unsafeAllocations,logDest=stderr,minAge=1");
+		runner.loadAgent("dump=unsafeAllocations,logDest=stderr,minAge=1m");
 		runner.kill();
 		assertLinesNotContainsRegExp(runner.getStderrLines(), "Allocated 570 bytes at", "Allocated 750 bytes at",
 				"Printed");

--- a/agent/src/test/java/org/openjdk/jmc/agent/sap/test/UnsafeAllocationTest.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/sap/test/UnsafeAllocationTest.java
@@ -74,7 +74,7 @@ public class UnsafeAllocationTest extends TestBase {
 
 	public void testNativeAllocsForJfr() throws Exception {
 		JavaAgentRunner runner = getRunnerWithJFR("traceUnsafeAllocations", "--add-opens",
-				"java.base/jdk.internal.misc=ALL-UNNAMED");
+				"java.base/jdk.internal.misc=ALL-UNNAMED", "-XX:NativeMemoryTracking=off");
 		runner.start(DO_NATIVE_ALLOCS_FOR_JFR);
 		runner.waitForEnd();
 		String[] lines = getJfrOutput("jdk.log.*", 16);


### PR DESCRIPTION
It turns out the native memory tracking in older VMs (17 at least) don't handle the to be failed allocations of 2^56 bytes too well, but crashes instead. So we disabled it for the test.

Additionally the help text for the minAge and maxAge was wrong.
